### PR TITLE
Remove default vaule of `_multiple_of` in `NumberSchema`

### DIFF
--- a/donttrust/schema.py
+++ b/donttrust/schema.py
@@ -324,7 +324,7 @@ class NumberSchema(Schema):
 
     _type = int
 
-    _multiple_of: int = 1
+    _multiple_of: int = None
 
     _add: int = None
     _subtract: int = None
@@ -343,7 +343,7 @@ class NumberSchema(Schema):
         if self._max and value > self._max:
             raise SizeException(self.field, self._max, True)
 
-        if value % self._multiple_of != 0:
+        if self._multiple_of and value % self._multiple_of != 0:
             raise MultipleException(self.field, self._multiple_of)
 
         if self._add:

--- a/tests/test_date_schema.py
+++ b/tests/test_date_schema.py
@@ -6,13 +6,14 @@ from donttrust.schema import Schema
 
 class Test(unittest.TestCase):
     def test_1(self):
-        schema = Schema("test1").date().required().min('today').max("2022-12-31")
+        # Remind me to change this in 28 years!
+        schema = Schema("test1").date().required().min('today').max("2049-12-31")
 
-        self.assertTrue(schema.validate_without_exception("2021-04-01"))
+        self.assertTrue(schema.validate("2049-04-01"))
         self.assertFalse(schema.validate_without_exception(None))
         self.assertFalse(schema.validate_without_exception("2020-12-10"))
         self.assertFalse(schema.validate_without_exception("dsa"))
-        self.assertFalse(schema.validate_without_exception("2023-01-01"))
+        self.assertFalse(schema.validate_without_exception("2053-01-01"))
 
     def test_2(self):
         schema = Schema().date()

--- a/tests/test_number_schema.py
+++ b/tests/test_number_schema.py
@@ -17,7 +17,7 @@ class Test(unittest.TestCase):
         self.assertFalse(schema.validate_without_exception(50000.0))
         self.assertFalse(schema.validate_without_exception(3.0))
         self.assertFalse(schema.validate_without_exception(19))
-        self.assertFalse(schema.validate_without_exception(None), None)
+        self.assertEqual(schema.validate_without_exception(None), None)
 
     def test_3(self):
         schema = Schema("test2.1").number()

--- a/tests/test_number_schema.py
+++ b/tests/test_number_schema.py
@@ -20,7 +20,7 @@ class Test(unittest.TestCase):
         self.assertEqual(schema.validate_without_exception(None), None)
 
     def test_3(self):
-        schema = Schema("test2.1").number()
+        schema = Schema("test3").number()
         self.assertFalse(schema.validate_without_exception("okaobkeokboerkoek"))
         self.assertEqual(schema.validate_without_exception(None), None)
 

--- a/tests/test_number_schema.py
+++ b/tests/test_number_schema.py
@@ -24,6 +24,16 @@ class Test(unittest.TestCase):
         self.assertFalse(schema.validate_without_exception("okaobkeokboerkoek"))
         self.assertEqual(schema.validate_without_exception(None), None)
 
+    def test_4(self):
+        schema = Schema("test4").number().float()
+        self.assertTrue(schema.validate_without_exception(3.14))
+        self.assertEqual(schema.validate_without_exception(None), None)
+
+    def test_5(self):
+        schema = Schema("test5").number().multiple(0.1).float()
+        self.assertTrue(schema.validate(1.0))
+        self.assertEqual(schema.validate_without_exception(None), None)
+
 
 def main():
     unittest.main()

--- a/tests/test_number_schema.py
+++ b/tests/test_number_schema.py
@@ -29,11 +29,6 @@ class Test(unittest.TestCase):
         self.assertTrue(schema.validate_without_exception(3.14))
         self.assertEqual(schema.validate_without_exception(None), None)
 
-    def test_5(self):
-        schema = Schema("test5").number().multiple(0.1).float()
-        self.assertTrue(schema.validate(1.0))
-        self.assertEqual(schema.validate_without_exception(None), None)
-
 
 def main():
     unittest.main()


### PR DESCRIPTION
This value is removed to allow float numbers to work with DontTrust.

Fixes #4 

Also added a test for floating numbers.